### PR TITLE
Integrate advanced analytics and ML predictions

### DIFF
--- a/dashboard_stripe/ml/revenue_model.py
+++ b/dashboard_stripe/ml/revenue_model.py
@@ -1,0 +1,28 @@
+import json
+import sys
+import numpy as np
+from sklearn.linear_model import LinearRegression
+
+# Simple training data: [followers, engagement_rate, avg_views] -> revenue
+TRAIN_X = np.array([
+    [10000, 0.02, 2000],
+    [50000, 0.05, 10000],
+    [200000, 0.04, 50000],
+    [1000000, 0.08, 200000],
+    [300000, 0.03, 70000]
+], dtype=float)
+TRAIN_Y = np.array([200, 3000, 8000, 50000, 12000], dtype=float)
+
+MODEL = LinearRegression().fit(TRAIN_X, TRAIN_Y)
+
+def predict(data):
+    x = np.array([[data.get('followers', 0),
+                   data.get('engagementRate', 0) / 100.0,
+                   data.get('avgViews', 0)]])
+    return float(MODEL.predict(x)[0])
+
+if __name__ == '__main__':
+    payload = sys.stdin.read() or '{}'
+    features = json.loads(payload)
+    result = predict(features)
+    print(json.dumps({'prediction': result}))

--- a/dashboard_stripe/tiktok_ai/package-lock.json
+++ b/dashboard_stripe/tiktok_ai/package-lock.json
@@ -9,12 +9,8 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@langchain/openai": "^0.0.14",
         "axios": "^1.6.0",
-        "compromise": "^14.10.0",
         "dotenv": "^16.3.1",
-        "langchain": "^0.0.208",
-        "natural": "^6.10.4",
         "node-cron": "^3.0.3",
         "openai": "^4.20.1",
         "sqlite3": "^5.1.6"

--- a/dashboard_stripe/tiktok_ai/package.json
+++ b/dashboard_stripe/tiktok_ai/package.json
@@ -10,10 +10,6 @@
   },
   "dependencies": {
     "openai": "^4.20.1",
-    "langchain": "^0.0.208",
-    "@langchain/openai": "^0.0.14",
-    "natural": "^6.10.4",
-    "compromise": "^14.10.0",
     "node-cron": "^3.0.3",
     "axios": "^1.6.0",
     "sqlite3": "^5.1.6",
@@ -22,7 +18,7 @@
   "devDependencies": {
     "nodemon": "^3.0.1"
   },
-  "keywords": ["tiktok", "ai", "analytics", "openai", "langchain"],
+  "keywords": ["tiktok", "ai", "analytics", "openai"],
   "author": "Six Scripts Software LLC",
   "license": "MIT"
 }

--- a/tiktok_scraping_scripts/integration_api.py
+++ b/tiktok_scraping_scripts/integration_api.py
@@ -176,7 +176,7 @@ class TikTokIntegrationAPI:
             video_data = self.scrape_video_data(username)
             earnings_data = self.get_earnings_analysis(username)
             engagement_data = self.get_engagement_analysis(username)
-            
+
             return {
                 "username": username,
                 "timestamp": datetime.now().isoformat(),
@@ -184,6 +184,9 @@ class TikTokIntegrationAPI:
                 "videos": video_data.get("videos", []),
                 "earnings": earnings_data.get("models", {}),
                 "engagement": engagement_data.get("engagement", {}),
+                "posting_windows": engagement_data.get("posting_windows", []),
+                "hashtag_lift": engagement_data.get("hashtag_lift", []),
+                "top_sound": engagement_data.get("top_sound"),
                 "errors": [
                     data.get("error") for data in [profile_data, video_data, earnings_data, engagement_data]
                     if data.get("error")


### PR DESCRIPTION
## Summary
- Surface posting windows, hashtag lift, and top sounds throughout scraping and dashboard layers
- Remove unused NLP/embedding libraries and enrich AI prompts with new analytics
- Add scikit-learn revenue model and combine ML estimates with GPT output

## Testing
- `npm test` *(fails: Cannot find module 'openai')*
- `python dashboard_stripe/ml/revenue_model.py <<<'{"followers":10000,"engagementRate":5,"avgViews":2000}'`


------
https://chatgpt.com/codex/tasks/task_e_68b1e1f1d8348321b113c140dfb4179d