### PR TITLE
Add pytest suites and CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,15 @@
+name: CI
+
+on:
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install pytest
+      - run: pytest

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+from datetime import datetime, timedelta
+import pathlib, sys
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / 'tiktok_scraping_scripts'))
+from analytics import hashtag_efficacy, posting_time_optimizer, sound_lifespan
+
+
+def test_hashtag_efficacy(monkeypatch) -> None:
+    videos = [
+        {'hashtags': ['test', '#Other'], 'views': 100, 'likes': 10, 'comments': 5, 'shares': 5},
+        {'hashtags': ['test'], 'views': 200, 'likes': 40, 'comments': 10, 'shares': 10},
+        {'hashtags': ['other'], 'views': 100, 'likes': 10, 'comments': 0, 'shares': 0},
+    ]
+    monkeypatch.setattr(
+        'analytics.hashtag_efficacy.load_videos_any',
+        lambda fp: videos,
+    )
+    result = hashtag_efficacy.hashtag_efficacy('user', min_uses=1, videos_file='x.json')
+    assert result['scores'][0]['hashtag'] == 'test'
+    assert result['hashtag_count'] == 2
+
+
+def test_posting_time_optimizer(monkeypatch) -> None:
+    base = datetime(2023, 1, 1, 10)
+    videos = [
+        {'create_time': base.timestamp(), 'views': 100, 'likes': 10, 'comments': 0, 'shares': 0},
+        {'create_time': (base + timedelta(days=7)).timestamp(), 'views': 100, 'likes': 20, 'comments': 0, 'shares': 0},
+        {'create_time': (base + timedelta(days=1, hours=1)).timestamp(), 'views': 100, 'likes': 30, 'comments': 0, 'shares': 0},
+        {'create_time': (base + timedelta(days=8, hours=1)).timestamp(), 'views': 100, 'likes': 40, 'comments': 0, 'shares': 0},
+    ]
+    monkeypatch.setattr(
+        'analytics.posting_time_optimizer.load_videos_any',
+        lambda fp: videos,
+    )
+    result = posting_time_optimizer.posting_time_optimizer('user', videos_file='x.json')
+    assert result['windows'][0]['day'] == 'Monday'
+    assert result['best_days'][0]['day'] == 'Monday'
+    assert result['best_hours'][0]['hour'] == 11
+
+
+def test_sound_lifespan(monkeypatch) -> None:
+    now = datetime.now()
+    videos = [
+        {'music': {'id': '1', 'title': 'Song1'}, 'views': 100, 'likes': 10, 'comments': 0, 'shares': 0, 'create_time': (now - timedelta(days=5)).timestamp()},
+        {'music': {'id': '1', 'title': 'Song1'}, 'views': 200, 'likes': 20, 'comments': 0, 'shares': 0, 'create_time': (now - timedelta(days=1)).timestamp()},
+        {'music': {'id': '2', 'title': 'Song2'}, 'views': 150, 'likes': 15, 'comments': 0, 'shares': 0, 'create_time': (now - timedelta(days=10)).timestamp()},
+    ]
+    monkeypatch.setattr(
+        'analytics.sound_lifespan.load_videos_any',
+        lambda fp: videos,
+    )
+    result = sound_lifespan.sound_lifespan(sound_id='1', username='u', videos_file='x.json')
+    assert result['sound_analysis']['total_uses'] == 2
+    assert result['sound_count'] == 1

--- a/tests/test_comments_scraper.py
+++ b/tests/test_comments_scraper.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+import types, sys
+
+class DummyBy:
+    CSS_SELECTOR = "css"
+
+selenium = types.ModuleType("selenium")
+webdriver = types.ModuleType("selenium.webdriver")
+common = types.ModuleType("selenium.webdriver.common")
+by_mod = types.ModuleType("selenium.webdriver.common.by")
+by_mod.By = DummyBy
+support = types.ModuleType("selenium.webdriver.support")
+support_ui = types.ModuleType("selenium.webdriver.support.ui")
+support_ui.WebDriverWait = object
+expected = types.ModuleType("selenium.webdriver.support.expected_conditions")
+expected.presence_of_element_located = lambda *a, **kw: None
+support.ui = support_ui
+support.expected_conditions = expected
+webdriver.common = common
+common.by = by_mod
+webdriver.support = support
+selenium.webdriver = webdriver
+selenium.webdriver.support = support
+common_ex = types.ModuleType("selenium.common.exceptions")
+common_ex.TimeoutException = Exception
+common_ex.WebDriverException = Exception
+common_ex.NoSuchElementException = Exception
+selenium.common = types.SimpleNamespace(exceptions=common_ex)
+
+sys.modules['selenium'] = selenium
+sys.modules['selenium.webdriver'] = webdriver
+sys.modules['selenium.webdriver.common'] = common
+sys.modules['selenium.webdriver.common.by'] = by_mod
+sys.modules['selenium.webdriver.support'] = support
+sys.modules['selenium.webdriver.support.ui'] = support_ui
+sys.modules['selenium.webdriver.support.expected_conditions'] = expected
+sys.modules['selenium.common'] = types.ModuleType('selenium.common')
+sys.modules['selenium.common.exceptions'] = common_ex
+
+import pathlib
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / 'tiktok_scraping_scripts'))
+from scrapers import comments_scraper
+
+class FakeElement:
+    def __init__(self, text: str = "", attrs: dict | None = None, children: dict | None = None) -> None:
+        self.text = text
+        self._attrs = attrs or {}
+        self._children = children or {}
+
+    def get_attribute(self, attr: str):
+        return self._attrs.get(attr)
+
+    def find_elements(self, how, sel):
+        return self._children.get((how, sel), [])
+
+
+def test_int_parsing() -> None:
+    assert comments_scraper._int('1.2K') == 1200
+    assert comments_scraper._int('3M') == 3_000_000
+    assert comments_scraper._int(None) is None
+
+
+def test_extract_comment_fields() -> None:
+    author = FakeElement(text='user', attrs={'href': 'https://tiktok.com/@user'})
+    text_el = FakeElement(text='hello world')
+    like_el = FakeElement(text='1.5K')
+    time_el = FakeElement(attrs={'title': '2023-01-01'})
+    tile = FakeElement(
+        attrs={'data-comment-id': 'c1'},
+        children={
+            ('css', "[data-e2e='comment-level1-username']"): [author],
+            ('css', "[data-e2e='comment-text']"): [text_el],
+            ('css', "[data-e2e='comment-like-count']"): [like_el],
+            ('css', "abbr[title], time[title]"): [time_el],
+        }
+    )
+    cid, user, text, likes, ts = comments_scraper._extract_comment_fields(tile)
+    assert cid == 'c1'
+    assert user == 'user'
+    assert text == 'hello world'
+    assert likes == 1500
+    assert ts == '2023-01-01'

--- a/tests/test_driver_loader.py
+++ b/tests/test_driver_loader.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+import importlib, types, sys, pathlib
+from pathlib import Path
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / 'tiktok_scraping_scripts'))
+import driver_loader
+
+
+def test_env_variable_overrides(monkeypatch) -> None:
+    monkeypatch.setenv('TIKTOK_DRIVER_FACTORY', 'math:sin')
+    factory = driver_loader.discover_driver_factory()
+    assert factory is importlib.import_module('math').sin
+
+
+def test_config_file_used(monkeypatch, tmp_path) -> None:
+    cfg_dir = tmp_path / 'tiktok_scraping_scripts'
+    cfg_dir.mkdir()
+    (cfg_dir / 'config.toml').write_text('[driver]\nfactory = "math:cos"', encoding='utf-8')
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv('TIKTOK_DRIVER_FACTORY', raising=False)
+    factory = driver_loader.discover_driver_factory()
+    assert factory is importlib.import_module('math').cos
+
+
+def test_fallback_to_ads(monkeypatch) -> None:
+    monkeypatch.delenv('TIKTOK_DRIVER_FACTORY', raising=False)
+    cfg = Path('tiktok_scraping_scripts/config.toml')
+    if cfg.exists():
+        cfg.unlink()
+    ads = types.ModuleType('anti_detection_system')
+    def create_driver() -> str:
+        return 'driver'
+    ads.create_driver = create_driver
+    monkeypatch.setitem(sys.modules, 'anti_detection_system', ads)
+    factory = driver_loader.discover_driver_factory()
+    assert factory() == 'driver'


### PR DESCRIPTION
## Summary
- add pytest coverage for scraper parsing, analytics metrics, and driver discovery
- mock selenium to test comment parsing without network access
- run tests on pull requests via GitHub Actions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1e0ccf9b4832188c554f42572605c